### PR TITLE
Experimental support for streaming references

### DIFF
--- a/client/src/main.ts
+++ b/client/src/main.ts
@@ -10,7 +10,7 @@ import ChildProcess = cp.ChildProcess;
 import {
 	workspace as Workspace, window as Window, languages as Languages, commands as Commands,
 	TextDocumentChangeEvent, TextDocument, Disposable, OutputChannel,
-	FileSystemWatcher, DiagnosticCollection, Uri,
+	FileSystemWatcher, DiagnosticCollection, Uri, ProgressCallback,
 	CancellationToken, Position as VPosition, Location as VLocation, Range as VRange,
 	CompletionItem as VCompletionItem, CompletionList as VCompletionList, SignatureHelp as VSignatureHelp, Definition as VDefinition, DocumentHighlight as VDocumentHighlight,
 	SymbolInformation as VSymbolInformation, CodeActionContext as VCodeActionContext, Command as VCommand, CodeLens as VCodeLens,
@@ -21,14 +21,14 @@ import {
 
 import {
 	Message, MessageType as RPCMessageType, Logger, createMessageConnection, ErrorCodes, ResponseError,
-	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler,
+	RequestType, RequestTypeWithStreamingResponse, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler,
 	NotificationType, NotificationType0,
 	NotificationHandler, NotificationHandler0, GenericNotificationHandler,
 	MessageReader, IPCMessageReader, MessageWriter, IPCMessageWriter, Trace, Tracer, Event, Emitter
 } from 'vscode-jsonrpc';
 
 import {
-	WorkspaceEdit
+	WorkspaceEdit, Location
 } from 'vscode-languageserver-types';
 
 
@@ -74,7 +74,7 @@ import * as UUID from './utils/uuid';
 
 export {
 	ResponseError, InitializeError, ErrorCodes,
-	RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler,
+	RequestTypeWithStreamingResponse, RequestType, RequestType0, RequestHandler, RequestHandler0, GenericRequestHandler,
 	NotificationType, NotificationType0, NotificationHandler, NotificationHandler0, GenericNotificationHandler
 }
 export { Converter as Code2ProtocolConverter } from './codeConverter';
@@ -94,6 +94,8 @@ interface IConnection {
 	sendRequest<R>(method: string, token?: CancellationToken): Thenable<R>;
 	sendRequest<R>(method: string, param: any, token?: CancellationToken): Thenable<R>;
 	sendRequest<R>(type: string | RPCMessageType, ...params: any[]): Thenable<R>;
+
+	sendRequestWithStreamingResponse<P, PC, R>(type: RequestTypeWithStreamingResponse<P, PC, R, any, any>, params: P, token?: CancellationToken, progress?: ProgressCallback<PC>): Thenable<R>;
 
 	onRequest<R, E, RO>(type: RequestType0<R, E, RO>, handler: RequestHandler0<R, E>): void;
 	onRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, handler: RequestHandler<P, R, E>): void;
@@ -167,6 +169,7 @@ function createConnection(input: any, output: any, errorHandler: ConnectionError
 		listen: (): void => connection.listen(),
 
 		sendRequest: <R>(type: string | RPCMessageType, ...params: any[]): Thenable<R> => connection.sendRequest(is.string(type) ? type : type.method, ...params),
+		sendRequestWithStreamingResponse: <P, PC, R>(type: RequestTypeWithStreamingResponse<P, PC, R, any, any>, params: P, token?: CancellationToken, progress?: ProgressCallback<PC>): Thenable<R> => connection.sendRequestWithStreamingResponse(type, params, token, progress),
 		onRequest: <R, E>(type: string | RPCMessageType, handler: GenericRequestHandler<R, E>): void => connection.onRequest(is.string(type) ? type : type.method, handler),
 
 		sendNotification: (type: string | RPCMessageType, params?: any): void => connection.sendNotification(is.string(type) ? type : type.method, params),
@@ -955,6 +958,19 @@ export class LanguageClient {
 			return this._resolvedConnection!.sendRequest<R>(type, ...params);
 		} catch (error) {
 			this.error(`Sending request ${is.string(type) ? type : type.method} failed.`, error);
+			throw error;
+		}
+	}
+
+	public sendRequestWithStreamingResponse<P, PC, R>(type: RequestTypeWithStreamingResponse<P, PC, R, any, any>, params: P, token?: CancellationToken, progress?: ProgressCallback<PC>): Thenable<R> {
+		if (!this.isConnectionActive()) {
+			throw new Error('Language client is not ready yet');
+		}
+		this.forceDocumentSync();
+		try {
+			return this._resolvedConnection!.sendRequestWithStreamingResponse(type, params, token, progress);
+		} catch (error) {
+			this.error(`Sending request ${type.method} failed.`, error);
 			throw error;
 		}
 	}
@@ -1989,8 +2005,30 @@ export class LanguageClient {
 
 	private createReferencesProvider(options: TextDocumentRegistrationOptions): Disposable {
 		return Languages.registerReferenceProvider(options.documentSelector!, {
-			provideReferences: (document: TextDocument, position: VPosition, options: { includeDeclaration: boolean; }, token: CancellationToken): Thenable<VLocation[]> => {
-				return this.sendRequest(ReferencesRequest.type, this._c2p.asReferenceParams(document, position, options), token).then(
+			provideReferences: (document: TextDocument, position: VPosition, options: { includeDeclaration: boolean; }, token: CancellationToken, progress: ProgressCallback<VLocation[]>): Thenable<VLocation[]> => {
+				const knownReferences = new Set<string>();
+				const patch2Locations = (locations: Location[]) => {
+					// Right now references contains the entire partial result up until this point.
+					// Since the data gets serialized over IPC to the main thread,
+					// only forward the new results as a performance optimization.
+					const references = this._p2c.asReferences(locations);
+					const newReferences: VLocation[] = [];
+					references.forEach((reference) => {
+						const id = [
+							reference.uri.toString(),
+							reference.range.start.line,
+							reference.range.start.character,
+							reference.range.end.line,
+							reference.range.end.character
+						].join(":")
+						if (!knownReferences.has(id)) {
+							newReferences.push(reference);
+						}
+						knownReferences.add(id);
+					});
+					progress(newReferences);
+				};
+				return this.sendRequestWithStreamingResponse(ReferencesRequest.type, this._c2p.asReferenceParams(document, position, options), token, patch2Locations).then(
 					this._p2c.asReferences,
 					(error) => {
 						this.logFailedRequest(ReferencesRequest.type, error);

--- a/client/src/protocol.ts
+++ b/client/src/protocol.ts
@@ -4,7 +4,7 @@
  * ------------------------------------------------------------------------------------------ */
 'use strict';
 
-import { RequestType, RequestType0, NotificationType, NotificationType0 } from 'vscode-jsonrpc';
+import { RequestType, RequestType0, RequestTypeWithStreamingResponse, NotificationType, NotificationType0 } from 'vscode-jsonrpc';
 
 import {
 	TextDocumentContentChangeEvent, Position, Range, Location, Diagnostic, Command,
@@ -1166,7 +1166,7 @@ export interface ReferenceParams extends TextDocumentPositionParams {
  * [Location[]](#Location) or a Thenable that resolves to such.
  */
 export namespace ReferencesRequest {
-	export const type = new RequestType<ReferenceParams, Location[], void, TextDocumentRegistrationOptions>('textDocument/references');
+	export const type = new RequestTypeWithStreamingResponse<ReferenceParams, Location[], Location[], void, TextDocumentRegistrationOptions>('textDocument/references');
 }
 
 //---- Document Highlight ----------------------------------

--- a/jsonrpc/package.json
+++ b/jsonrpc/package.json
@@ -16,6 +16,9 @@
 	},
 	"main": "./lib/main.js",
 	"typings": "./lib/main.d.ts",
+	"dependencies": {
+		"fast-json-patch": "^1.1.5"
+	},
 	"devDependencies": {
 		"mocha": "^3.1.0",
 		"typescript": "^2.1.5",

--- a/jsonrpc/src/main.ts
+++ b/jsonrpc/src/main.ts
@@ -9,6 +9,7 @@ import * as is from './is';
 
 import {
 	Message, MessageType,
+	RequestTypeWithStreamingResponse,
 	RequestMessage, RequestType, isRequestMessage,
 	RequestType0, RequestType1, RequestType2, RequestType3, RequestType4,
 	RequestType5, RequestType6, RequestType7, RequestType8, RequestType9,
@@ -25,7 +26,7 @@ import { CancellationTokenSource, CancellationToken } from './cancellation';
 
 export {
 	Message, MessageType, ErrorCodes, ResponseError,
-	RequestMessage, RequestType,
+	RequestMessage, RequestType, RequestTypeWithStreamingResponse,
 	RequestType0, RequestType1, RequestType2, RequestType3, RequestType4,
 	RequestType5, RequestType6, RequestType7, RequestType8, RequestType9,
 	NotificationMessage, NotificationType,
@@ -37,6 +38,12 @@ export {
 	Disposable, Event, Emitter
 }
 
+// TODO(nick): fast-json-patch does not have typescript bindings yet
+// https://github.com/Starcounter-Jack/JSON-Patch/issues/129
+// https://github.com/Starcounter-Jack/JSON-Patch/issues/146
+// import * as jsonpatch from 'fast-json-patch';
+const jsonpatch = require('fast-json-patch');
+
 interface CancelParams {
 	/**
 	 * The request id to cancel.
@@ -47,6 +54,42 @@ interface CancelParams {
 namespace CancelNotification {
 	export const type = new NotificationType<CancelParams, void>('$/cancelRequest');
 }
+
+export interface PartialResultParams {
+	/**
+	 * The JSON RPC id of the request that this partial result is associated with.
+	 */
+	id: number | string,
+
+	/**
+	 * A JSON Patch.
+	 * http://jsonpatch.com/
+	 */
+	patch: any
+}
+
+export namespace PartialResultNotification {
+	export const type = new NotificationType<PartialResultParams, void>('$/partialResult');
+}
+
+interface PartialResultHandler<T> {
+
+	/**
+	 * The callback to call when partialValue is updated.
+	 */
+	callback: PartialResultCallback<T>;
+
+	/**
+	 * The cumulative partial result value that has been
+	 * constructed by applying all JSON Patch operations.
+	 */
+	partialValue: T;
+}
+
+/**
+ * A function that is called with a partial result object for a request.
+ */
+export type PartialResultCallback<T> = (value: T) => void;
 
 export interface GenericRequestHandler<R, E> {
 	(...params: any[]): R | ResponseError<E> | Thenable<R> | Thenable<ResponseError<E>>;
@@ -220,6 +263,9 @@ export interface MessageConnection {
 	sendRequest<P1, P2, P3, P4, P5, P6, P7, P8, P9, R, E, RO>(type: RequestType9<P1, P2, P3, P4, P5, P6, P7, P8, P9, R, E, RO>, p1: P1, p2: P2, p3: P3, p4: P4, p5: P5, p6: P6, p7: P7, p8: P8, p9: P9, token?: CancellationToken): Thenable<R>;
 	sendRequest<R>(method: string, ...params: any[]): Thenable<R>;
 
+	sendRequestHelper<R, PC>(method: string, params: any, token?: CancellationToken, progress?: PartialResultCallback<PC>): Thenable<R>;
+	sendRequestWithStreamingResponse<P, PC, R>(type: RequestTypeWithStreamingResponse<P, PC, R, any, any>, params: P, token?: CancellationToken, progress?: PartialResultCallback<PC>): Thenable<R>;
+
 	onRequest<R, E, RO>(type: RequestType0<R, E, RO>, handler: RequestHandler0<R, E>): void;
 	onRequest<P, R, E, RO>(type: RequestType<P, R, E, RO>, handler: RequestHandler<P, R, E>): void;
 	onRequest<P1, R, E, RO>(type: RequestType1<P1, R, E, RO>, handler: RequestHandler1<P1, R, E>): void;
@@ -301,6 +347,7 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 	let closeEmitter: Emitter<void> = new Emitter<void>();
 	let unhandledNotificationEmitter: Emitter<NotificationMessage> = new Emitter<NotificationMessage>();
 	let disposeEmitter: Emitter<void> = new Emitter<void>();
+	let partialResultHandlers = new Map<String, PartialResultHandler<any>>();
 
 	function isListening(): boolean {
 		return state === ConnectionState.Listening;
@@ -442,6 +489,7 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 		}
 
 		let key = String(responseMessage.id);
+		partialResultHandlers.delete(key);
 		let responsePromise = responsePromises[key];
 		traceReceviedResponse(responseMessage, responsePromise);
 		if (responsePromise) {
@@ -477,6 +525,14 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 				let source = requestTokens[String(id)];
 				if (source) {
 					source.cancel();
+				}
+			}
+		} if (message.method === PartialResultNotification.type.method) {
+			notificationHandler = (params: PartialResultParams) => {
+				const handler = partialResultHandlers.get(String(params.id));
+				if (handler) {
+					jsonpatch.apply(handler.partialValue, params.patch, false);
+					handler.callback(handler.partialValue);
 				}
 			}
 		} else {
@@ -704,7 +760,7 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 
 			notificationHandlers[is.string(type) ? type : type.method] = handler;
 		},
-		sendRequest: <R, E>(type: string | MessageType, ...params: any[]) => {
+		sendRequest: <R>(type: string | MessageType, ...params: any[]): Thenable<R> => {
 			throwIfClosedOrDisposed();
 
 			let method: string;
@@ -745,14 +801,16 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 				let numberOfParams = type.numberOfParams;
 				token = CancellationToken.is(params[numberOfParams]) ? params[numberOfParams] : undefined;
 			}
-
+			return connection.sendRequestHelper(method, messageParams, token);
+		},
+		sendRequestHelper: <R, PC>(method: string, params: any, token?: CancellationToken, progress?: PartialResultCallback<PC>): Thenable<R> => {
 			let id = sequenceNumber++;
-			let result = new Promise<R | ResponseError<E>>((resolve, reject) => {
+			let result = new Promise<R | ResponseError<void>>((resolve, reject) => {
 				let requestMessage: RequestMessage = {
 					jsonrpc: version,
 					id: id,
 					method: method,
-					params: messageParams
+					params: params
 				}
 				let responsePromise: ResponsePromise | null = { method: method, timerStart: Date.now(), resolve, reject };
 				traceSendingRequest(requestMessage);
@@ -762,6 +820,18 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 					// Writing the message failed. So we need to reject the promise.
 					responsePromise.reject(new ResponseError<void>(ErrorCodes.MessageWriteError, e.message ? e.message : 'Unknown reason'));
 					responsePromise = null;
+				}
+				if (progress) {
+					partialResultHandlers.set(String(id), {
+						callback: progress,
+
+						// TODO(nick): This initial array value is a hack because the JSON Patch library that we are using
+						// does not support changing the type of the root document.
+						// See https://github.com/Starcounter-Jack/JSON-Patch/issues/147
+						// Since our first use-case is streaming references, and the type of that response is an array,
+						// initialize the partial result to an empty array.
+						partialValue: [], 
+					});
 				}
 				if (responsePromise) {
 					responsePromises[String(id)] = responsePromise;
@@ -773,6 +843,9 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 				});
 			}
 			return result;
+		},
+		sendRequestWithStreamingResponse: <P, PC, R>(type: RequestTypeWithStreamingResponse<P, PC, R, any, any>, params: P, token?: CancellationToken, progress?: PartialResultCallback<PC>): Thenable<R> => {
+			return connection.sendRequestHelper(type.method, params, token, progress);
 		},
 		onRequest: <R, E>(type: string | MessageType, handler: GenericRequestHandler<R, E>): void => {
 			throwIfClosedOrDisposed();
@@ -806,6 +879,7 @@ function _createMessageConnection(messageReader: MessageReader, messageWriter: M
 			});
 			responsePromises = Object.create(null);
 			requestTokens = Object.create(null);
+			partialResultHandlers.clear();
 		},
 		listen: () => {
 			throwIfClosedOrDisposed();

--- a/jsonrpc/src/messages.ts
+++ b/jsonrpc/src/messages.ts
@@ -173,6 +173,13 @@ export class RequestType<P, R, E, RO> extends AbstractMessageType {
 	}
 }
 
+export class RequestTypeWithStreamingResponse<Params, ProgressCallback, Result, Error, RegistrationOptions> extends AbstractMessageType {
+	private _?: [Params, ProgressCallback, Result, Error, RegistrationOptions, _EM];
+	constructor(method: string) {
+		super(method, 1);
+		this._ = undefined;
+	}
+}
 
 export class RequestType1<P1, R, E, RO> extends AbstractMessageType {
 	private _?: [P1, R, E, RO, _EM];


### PR DESCRIPTION
Internal PR for us to review. I have this working end-to-end locally.

The vscode-jsonrpc layer applies the patches and forwards the cumulative partial result (so higher layers don't need to care about json patch).

Methods in vscode-languageclient may choose to forward this as-is or perform performance optimizations to only send new data since the data gets serialized over RPC. For streaming references I implemented this performance optimization.